### PR TITLE
Support for other OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore
 
 pyenv/
+path.json
 
 # Node
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,23 @@ You can run python.exe or pip.exe in that environment.
 
 ## Test Case
 
-- Windows 10
+Windows 10
+
 - Node.js: v20.10.0
 - npm: 9.1.3
-- Python 3.8.3
-- pip 24.0
+- Python: 3.8.3
+- pip: 24.0
+
+Raspberry Pi
+
+- Debian bookworm
+- Node.js: v18.19.0
+- npm: 9.2.0
+- Python: 3.11.2
+- pip: 24.0
 
 Sample flows are in the examples folder.  
 ![sample-flow.jpg](./img/sample-flow.jpg)
-
 
 ## Nodes
 

--- a/node/pip.js
+++ b/node/pip.js
@@ -2,14 +2,17 @@ module.exports = function(RED) {
     function Pip(config) {
         RED.nodes.createNode(this,config)
         let node = this
+        let argument = ''
+        let action = ''
+        let command = ''
+        const path = require('path')
+        const fs = require('fs')
+        const jsonPath = path.join(path.dirname(__dirname), 'path.json')
+        const json = fs.readFileSync(jsonPath)
+        const pathPip = JSON.parse(json).NODE_PYENV_PIP
+        const execSync = require('child_process').execSync
 
         node.on('input', function(msg) {
-            const path = require('path')
-            const pathPip = path.join(path.dirname(__dirname), 'pyenv/Scripts/pip.exe')
-            let argument = ''
-            let action = ''
-            let command = ''
-
             if(config.arg !== null && config.arg !== '') {
                 argument = config.arg
             } else {
@@ -36,8 +39,6 @@ module.exports = function(RED) {
                     break
             }
             command = pathPip + ' ' + action + ' ' + option + ' ' + argument
-
-            let execSync = require('child_process').execSync
             msg.payload = String(execSync(command))
             node.send(msg)
         })

--- a/node/venv.js
+++ b/node/venv.js
@@ -6,7 +6,9 @@ module.exports = function(RED) {
         const fs = require('fs')
         const path = require('path')
         const filePath = path.join(path.dirname(__dirname), 'tmp', this.id + '.py')
-        const pythonPath = path.join(path.dirname(__dirname), 'pyenv/Scripts/python.exe')
+        const jsonPath = path.join(path.dirname(__dirname), 'path.json')
+        const json = fs.readFileSync(jsonPath)
+        const pythonPath = JSON.parse(json).NODE_PYENV_PYTHON
         let code = ""
 
         node.on('input', function(msg) {

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,15 @@ import json
 
 absDir = os.path.dirname(os.path.abspath(__file__))
 subprocess.run(['python', '-m', 'venv', 'pyenv'])
-subprocess.run([f'{absDir}/pyenv/Scripts/python.exe', '-m', 'pip', 'install', '--upgrade', 'pip'])
 
 if os.name == 'nt':
+    subprocess.run([f'{absDir}/pyenv/Scripts/python.exe', '-m', 'pip', 'install', '--upgrade', 'pip'])
     path = {
         'NODE_PYENV_PYTHON': f'{absDir}/pyenv/Scripts/python.exe',
         'NODE_PYENV_PIP': f'{absDir}/pyenv/Scripts/pip.exe'
     }
 else:
+    subprocess.run([f'{absDir}/pyenv/bin/python', '-m', 'pip', 'install', '--upgrade', 'pip'])
     path = {
         'NODE_PYENV_PYTHON': f'{absDir}/pyenv/bin/python',
         'NODE_PYENV_PIP': f'{absDir}/pyenv/bin/pip'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,21 @@
 import subprocess
 import os
+import json
 
 absDir = os.path.dirname(os.path.abspath(__file__))
-subprocess.run('python -m venv pyenv')
-subprocess.run(f'{absDir}/pyenv/Scripts/python.exe -m pip install --upgrade pip')
+subprocess.run(['python', '-m', 'venv', 'pyenv'])
+subprocess.run([f'{absDir}/pyenv/Scripts/python.exe', '-m', 'pip', 'install', '--upgrade', 'pip'])
+
+if os.name == 'nt':
+    path = {
+        'NODE_PYENV_PYTHON': f'{absDir}/pyenv/Scripts/python.exe',
+        'NODE_PYENV_PIP': f'{absDir}/pyenv/Scripts/pip.exe'
+    }
+else:
+    path = {
+        'NODE_PYENV_PYTHON': f'{absDir}/pyenv/bin/python',
+        'NODE_PYENV_PIP': f'{absDir}/pyenv/bin/pip'
+    }
+
+with open(f'{absDir}/path.json', 'w') as f:
+    json.dump(path, f, indent=2)


### PR DESCRIPTION
#1 Differences in Python virtual environment file structure depending on OS

To resolve the issue, I changed the paths below for other environments not on Windows.

- pyenv/Scripts/python.exe -> pyenv/bin/python
- pyenv/Scripts/pip -> pyenv/bin/pip

I tested this node on a Raspberry Pi, and it works.  
File paths are shared in path.json.  