### PR TITLE
Pass Node-RED message to Python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python.exe is in the ./pyenv/Scripts/python.exe
 
 Write your Python code in the node.  
 The program is saved in a tmp folder and executed.  
+You can access Node-RED messages like `print(msg['payload'])`
 
 ![venv-node.jpg](./img/venv-node.png)
 

--- a/node/venv.js
+++ b/node/venv.js
@@ -12,7 +12,8 @@ module.exports = function(RED) {
         let code = ""
 
         node.on('input', function(msg) {
-            const command = pythonPath + ' ' + filePath
+            let command = pythonPath + ' ' + filePath
+            command = command + " --payload='" + JSON.stringify(msg.payload) + "'"
 
             if(config.code !== null && config.code !== "") {
                 code = config.code

--- a/node/venv.js
+++ b/node/venv.js
@@ -12,8 +12,11 @@ module.exports = function(RED) {
         let code = ""
 
         node.on('input', function(msg) {
-            let command = pythonPath + ' ' + filePath
-            command = command + " --payload='" + JSON.stringify(msg.payload) + "'"
+            // Base64 encoded JSON string of the message:
+            const message = Buffer.from(JSON.stringify({
+                "payload": msg.payload,
+            })).toString('base64')
+            const command = `${pythonPath} -c 'import base64;import json;msg=json.loads(base64.b64decode("${message}"));exec(open("${filePath}").read())'`
 
             if(config.code !== null && config.code !== "") {
                 code = config.code


### PR DESCRIPTION
Allow something like `print(msg['payload'])`
fix https://github.com/404background/node-red-contrib-python-venv/issues/4
![image](https://github.com/404background/node-red-contrib-python-venv/assets/1008324/c2401952-739a-4a2b-bc58-ea7bb74e8aa5)
