### PR TITLE
Use spawn instead of exec to support larger output payloads

### DIFF
--- a/node/venv.js
+++ b/node/venv.js
@@ -10,22 +10,41 @@ module.exports = function(RED) {
         const json = fs.readFileSync(jsonPath)
         const pythonPath = JSON.parse(json).NODE_PYENV_PYTHON
 
-        const execSync = require('child_process').execSync
-        let code = ""
+        const child_process = require('child_process')
 
         node.on('input', function(msg) {
-            const message = Buffer.from(JSON.stringify(msg)).toString('base64')
-            const command = `${pythonPath} -c "import base64;import json;msg=json.loads(base64.b64decode(r'${message}'));exec(open(r'${filePath}').read())"`
-
-            if(config.code !== null && config.code !== "") {
+            let code = ''
+            if(config.code !== null && config.code !== '') {
                 code = config.code
             } else {
                 code = msg.code
             }
             fs.writeFileSync(filePath, code)
             
-            msg.payload = String(execSync(command))
-            node.send(msg)
+            const message = Buffer.from(JSON.stringify(msg)).toString('base64')
+            const args = ['-c', `import base64;import json;msg=json.loads(base64.b64decode(r'${message}'));exec(open(r'${filePath}').read())`]
+            const pythonProcess = child_process.spawn(pythonPath, args)
+            let stdoutData = ''
+            let stderrData = ''
+
+            pythonProcess.on('message', console.log)
+
+            pythonProcess.stdout.on('data', (chunk) => {
+                stdoutData += chunk.toString()
+            })
+            
+            pythonProcess.stderr.on('data', (chunk) => {
+                stderrData += chunk.toString()
+            })
+            
+            pythonProcess.on('close', (exitCode) => {
+                if (exitCode !== 0) {
+                    node.error(stderrData)
+                } else {
+                    msg.payload = stdoutData
+                    node.send(msg)
+                }
+            })
         })
     }
     RED.nodes.registerType("venv", Venv)

--- a/node/venv.js
+++ b/node/venv.js
@@ -20,7 +20,7 @@ module.exports = function(RED) {
                 code = msg.code
             }
             fs.writeFileSync(filePath, code)
-            
+
             const message = Buffer.from(JSON.stringify(msg)).toString('base64')
             const args = ['-c', `import base64;import json;msg=json.loads(base64.b64decode(r'${message}'));exec(open(r'${filePath}').read())`]
             const pythonProcess = child_process.spawn(pythonPath, args)
@@ -32,11 +32,11 @@ module.exports = function(RED) {
             pythonProcess.stdout.on('data', (chunk) => {
                 stdoutData += chunk.toString()
             })
-            
+
             pythonProcess.stderr.on('data', (chunk) => {
                 stderrData += chunk.toString()
             })
-            
+
             pythonProcess.on('close', (exitCode) => {
                 if (exitCode !== 0) {
                     node.error(stderrData)

--- a/node/venv.js
+++ b/node/venv.js
@@ -39,11 +39,13 @@ module.exports = function(RED) {
 
             pythonProcess.on('close', (exitCode) => {
                 if (exitCode !== 0) {
-                    node.error(stderrData)
+                    node.error(`Error ${exitCode}: ` + stderrData)
                 } else {
                     msg.payload = stdoutData
                     node.send(msg)
                 }
+                stdoutData = ''
+                stderrData = ''
             })
         })
     }


### PR DESCRIPTION
Fix for `Error: spawnSync /bin/sh ENOBUFS` when the data returned by the Python script is too large.

Inspired by https://stackoverflow.com/questions/63796633/spawnsync-bin-sh-enobufs

Test Python script:

```python
def generate_large_string():
	large_string = 'A' * 5000000
	return large_string

result = generate_large_string()
print(result)
```

Test JavaScript function;

```js
msg.payload = msg.payload.length;
return msg;
```

<details>
<summary>flows.json</summary>

```json
[
    {
        "id": "f14c248431d474e8",
        "type": "inject",
        "z": "f6f2187d.f17ca8",
        "name": "",
        "props": [
            {
                "p": "payload"
            },
            {
                "p": "topic",
                "vt": "str"
            }
        ],
        "repeat": "",
        "crontab": "",
        "once": false,
        "onceDelay": 0.1,
        "topic": "",
        "payload": "",
        "payloadType": "date",
        "x": 130,
        "y": 260,
        "wires": [
            [
                "8be43bb7c337f2b3"
            ]
        ]
    },
    {
        "id": "b50cd141069d9975",
        "type": "debug",
        "z": "f6f2187d.f17ca8",
        "name": "debug 1",
        "active": true,
        "tosidebar": true,
        "console": false,
        "tostatus": false,
        "complete": "false",
        "statusVal": "",
        "statusType": "auto",
        "x": 740,
        "y": 260,
        "wires": []
    },
    {
        "id": "8be43bb7c337f2b3",
        "type": "venv",
        "z": "f6f2187d.f17ca8",
        "name": "",
        "code": "def generate_large_string():\n\tlarge_string = 'A' * 5000000\n\treturn large_string\n\nresult = generate_large_string()\nprint(result)\n",
        "x": 350,
        "y": 260,
        "wires": [
            [
                "9dcaea21518426b1"
            ]
        ]
    },
    {
        "id": "9dcaea21518426b1",
        "type": "function",
        "z": "f6f2187d.f17ca8",
        "name": "function 1",
        "func": "msg.payload = msg.payload.length;\nreturn msg;",
        "outputs": 1,
        "timeout": 0,
        "noerr": 0,
        "initialize": "",
        "finalize": "",
        "libs": [],
        "x": 540,
        "y": 260,
        "wires": [
            [
                "b50cd141069d9975"
            ]
        ]
    }
]
```
</details>
