### PR TITLE
Venv naming with space fix

### DIFF
--- a/node/pip.js
+++ b/node/pip.js
@@ -1,15 +1,18 @@
 module.exports = function(RED) {
     function Pip(config) {
         RED.nodes.createNode(this,config)
-        let node = this
+        const node = this
         this.venvconfig = RED.nodes.getNode(config.venvconfig)
 
         const path = require('path')
         const fs = require('fs')
-        let jsonPath = path.join(path.dirname(__dirname), 'pyenv', 'path.json')
-        if(this.venvconfig) {
-            jsonPath = path.join(path.dirname(__dirname), this.venvconfig.venvname, 'path.json')
+        
+        if(!this.venvconfig) {
+            node.send({ payload:"Missing virtual environment configuration"})
+            return
         }
+
+        const jsonPath = path.join(path.dirname(__dirname), this.venvconfig.venvname, 'path.json')
         const json = fs.readFileSync(jsonPath)
         const pipPath = JSON.parse(json).NODE_PYENV_PIP
         const child_process = require('child_process')

--- a/node/venv-config.html
+++ b/node/venv-config.html
@@ -3,7 +3,7 @@
         category: 'config',
         defaults: {
             venvname: {value:"pyenv", required: true},
-            version: {value:""}
+            version: {value:"default"}
         },
         label: function() {
             const version = this.version || 'default'

--- a/node/venv-config.js
+++ b/node/venv-config.js
@@ -10,9 +10,9 @@ module.exports = function(RED) {
         const setupPath = path.join(path.dirname(__dirname), 'setup.py')
         let venvPath = path.join(path.dirname(__dirname), this.venvname)
 
-        let command = `python ${setupPath} ${this.venvname}`
+        let command = `python ${setupPath} '${this.venvname}'`
         if(typeof this.version !== 'undefined' && this.version !== '') {
-            command = `python ${setupPath} ${this.venvname} ${this.version}`
+            command += ` ${this.version}`
         }
         execSync(command)
 

--- a/node/venv-config.js
+++ b/node/venv-config.js
@@ -10,8 +10,8 @@ module.exports = function(RED) {
         const setupPath = path.join(path.dirname(__dirname), 'setup.py')
         let venvPath = path.join(path.dirname(__dirname), this.venvname)
 
-        let command = `python ${setupPath} '${this.venvname}'`
-        if(typeof this.version !== 'undefined' && this.version !== '') {
+        let command = `python ${setupPath} "${this.venvname}"`
+        if(typeof this.version !== 'undefined' && this.version !== '' && this.version !== 'default') {
             command += ` ${this.version}`
         }
         execSync(command)

--- a/node/venv.js
+++ b/node/venv.js
@@ -1,23 +1,25 @@
 module.exports = function(RED) {
     function Venv(config) {
         RED.nodes.createNode(this,config)
-        let node = this
+        const node = this
         this.venvconfig = RED.nodes.getNode(config.venvconfig)
-        node.status({fill:"green", shape:"dot", text:"Standby"})
-        let runningScripts = 0
+
+        if(!this.venvconfig) {
+            node.send({ payload:"Missing virtual environment configuration"})
+            return
+        }
 
         const fs = require('fs')
         const path = require('path')
         const child_process = require('child_process')
 
-        let jsonPath = path.join(path.dirname(__dirname), 'pyenv', 'path.json')
-        let filePath = path.join(path.dirname(__dirname), 'tmp', this.id + '.py')
-        if(this.venvconfig) {
-            jsonPath = path.join(path.dirname(__dirname), this.venvconfig.venvname, 'path.json')
-            filePath = path.join(path.dirname(__dirname), this.venvconfig.venvname, this.id + '.py')
-        }
-        let json = fs.readFileSync(jsonPath)
-        let pythonPath = JSON.parse(json).NODE_PYENV_PYTHON
+        node.status({fill:"green", shape:"dot", text:"Standby"})
+        let runningScripts = 0
+
+        const jsonPath = path.join(path.dirname(__dirname), this.venvconfig.venvname, 'path.json')
+        const filePath = path.join(path.dirname(__dirname), this.venvconfig.venvname, this.id + '.py')
+        const json = fs.readFileSync(jsonPath)
+        const pythonPath = JSON.parse(json).NODE_PYENV_PYTHON
 
         node.on('input', function(msg) {
             runningScripts++


### PR DESCRIPTION
Fixed venv names with spaces breaking.
Additonally added a check for venv existing such that the nodes will not function before a venv is selected.
In addition also added "default" to the version displayed when entering the venv configuration for the first time to make it clearer that it is an option.