### PR TITLE
Fix UnicodeEncodeError and Garbled Characters

### DIFF
--- a/node/venv.js
+++ b/node/venv.js
@@ -56,7 +56,7 @@ module.exports = function (RED) {
       } else {
         code = msg.code ?? ''
       }
-      fs.writeFileSync(filePath, code)
+      fs.writeFileSync(filePath, code, { encoding: 'utf-8' })
 
       const message = Buffer.from(JSON.stringify(msg)).toString('base64')
       const args = [
@@ -85,13 +85,12 @@ module.exports = function (RED) {
         })
       }
 
-      pythonProcess = child_process.spawn(pythonPath, args)
-
       pythonProcess.on('message', console.log)
+      const env = { ...process.env, PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' }
+      pythonProcess = child_process.spawn(pythonPath, args, { env })
 
       pythonProcess.stdout.on('data', chunk => {
-        stdoutData += chunk.toString()
-
+        stdoutData += chunk.toString('utf8')
         // In continuous mode, send the output line by line
         if (continuous && stdoutData.endsWith('\n')) {
           msg.payload = stdoutData
@@ -101,7 +100,7 @@ module.exports = function (RED) {
       })
 
       pythonProcess.stderr.on('data', chunk => {
-        const err = chunk.toString()
+        const err = chunk.toString('utf8')
         stderrData += err
         rollingStderrData += err
         // In continuous mode, send errors line by line

--- a/node/venv.js
+++ b/node/venv.js
@@ -85,9 +85,9 @@ module.exports = function (RED) {
         })
       }
 
-      pythonProcess.on('message', console.log)
       const env = { ...process.env, PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' }
       pythonProcess = child_process.spawn(pythonPath, args, { env })
+      pythonProcess.on('message', console.log)
 
       pythonProcess.stdout.on('data', chunk => {
         stdoutData += chunk.toString('utf8')


### PR DESCRIPTION
Closes #29 
Closes #37 

Before the change, UnicodeEncodeError was occurring with environment-dependent characters.
Also, when Japanese characters were output, they were garbled.
![スクリーンショット 2024-11-02 215259](https://github.com/user-attachments/assets/f5e04173-4687-45f9-ac87-493f15a6d65a)
![スクリーンショット 2024-11-02 215229](https://github.com/user-attachments/assets/0a08b9c1-4940-47d6-886f-9a7626c2ed3e)
![スクリーンショット 2024-11-02 215604](https://github.com/user-attachments/assets/093f0b12-cd9d-4408-a8a7-f482a9169334)


When I changed the output to be in UTF-8, it was output without error.
![image](https://github.com/user-attachments/assets/3d933963-ebbc-4f4b-904c-5a7eb3ffc6c6)
![image](https://github.com/user-attachments/assets/f0974ae5-195d-4699-a1a7-99ddbe13b481)
![スクリーンショット 2024-11-02 201718](https://github.com/user-attachments/assets/cb72c61e-f624-46b6-8bcb-a40874b08272)
![スクリーンショット 2024-11-02 224408](https://github.com/user-attachments/assets/1aa37964-1f10-4a90-b426-5fd9e072a802)
![image](https://github.com/user-attachments/assets/40ad2409-4305-49ad-95e4-df9c27ae51d2)



There are likely to be some characters that cannot be displayed yet, but more mathematical symbols, Japanese, Kanji, and pictograms can be displayed.

Here is the flow.
```
[{"id":"f41e69dac2130d2e","type":"venv","z":"68da015e57374ead","venvconfig":"2b21ae15341abd9a","name":"","code":"print('Ω')","continuous":false,"x":370,"y":160,"wires":[["20bba8b29513b6b8"]]},{"id":"80351ba4c9fc5be3","type":"inject","z":"68da015e57374ead","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":200,"y":160,"wires":[["f41e69dac2130d2e"]]},{"id":"20bba8b29513b6b8","type":"debug","z":"68da015e57374ead","name":"debug 1","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":520,"y":160,"wires":[]},{"id":"ce24f513d606124f","type":"venv","z":"68da015e57374ead","venvconfig":"2b21ae15341abd9a","name":"","code":"invalid_chars = []\n\nfor codepoint in range(0x110000):  # 0x10FFFFまでのUnicode範囲\n    try:\n        char = chr(codepoint)\n        print(char, end=\"\")\n    except Exception as e:\n        # 例外が発生したコードポイントを記録\n        invalid_chars.append(codepoint)\n\n# 表示できなかったコードポイントを出力\nif invalid_chars:\n    print(\"\\n表示できなかったコードポイント:\")\n    for codepoint in invalid_chars:\n        print(f\"U+{codepoint:04X}\")\n","continuous":false,"x":370,"y":220,"wires":[["0c2f68a8577eeb89"]]},{"id":"12588ae37825964c","type":"inject","z":"68da015e57374ead","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":200,"y":220,"wires":[["ce24f513d606124f"]]},{"id":"0c2f68a8577eeb89","type":"debug","z":"68da015e57374ead","name":"debug 2","active":true,"tosidebar":true,"console":true,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":530,"y":220,"wires":[]},{"id":"4ce11798ee9734df","type":"venv","z":"68da015e57374ead","venvconfig":"2b21ae15341abd9a","name":"","code":"# ひらがな、カタカナ、漢字の範囲\nfor codepoint in range(0x3040, 0x30FF):  # ひらがな・カタカナ\n    print(chr(codepoint), end=\"\")\n\nfor codepoint in range(0x4E00, 0x9FFF):  # 漢字\n    print(chr(codepoint), end=\"\")\n\n# 一部の絵文字・環境依存文字の範囲\nfor codepoint in range(0x1F300, 0x1F5FF):  # 絵文字\n    print(chr(codepoint), end=\"\")\n","continuous":false,"x":370,"y":280,"wires":[["b9e91d43ad915228"]]},{"id":"ad350d8fe40e1cc4","type":"inject","z":"68da015e57374ead","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":200,"y":280,"wires":[["4ce11798ee9734df"]]},{"id":"b9e91d43ad915228","type":"debug","z":"68da015e57374ead","name":"debug 3","active":true,"tosidebar":true,"console":true,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":530,"y":280,"wires":[]},{"id":"57bf743e6aa38343","type":"venv","z":"68da015e57374ead","venvconfig":"2b21ae15341abd9a","name":"","code":"import unicodedata\n\n# 数学記号や特殊文字のUnicodeブロックの範囲\nblocks = [\n    (0x2200, 0x22FF),  # Mathematical Operators\n    (0x1D400, 0x1D7FF),  # Mathematical Alphanumeric Symbols\n    (0x2A00, 0x2AFF),  # Supplemental Mathematical Operators\n    (0x27C0, 0x27EF),  # Miscellaneous Mathematical Symbols-A\n    (0x1D68A, 0x1D6A5),  # Mathematical Script Small Letters\n    (0x1D6A8, 0x1D6C0),  # Mathematical Script Capital Letters\n    (0x1D6F0, 0x1D6FF),  # Mathematical Symbols\n    (0x1D6E0, 0x1D6E8),  # Mathematical Bold Letters\n]\n\n# 対象のUnicodeブロックの文字をprint\nfor start, end in blocks:\n    for code in range(start, end + 1):\n        char = chr(code)\n        try:\n            # Unicode名を取得し、表示\n            name = unicodedata.name(char)\n            print(char, end=' ')\n        except ValueError:\n            continue  # 名前が存在しない場合はスキップ\n","continuous":false,"x":370,"y":340,"wires":[["9e5ee9ee49efea8b"]]},{"id":"c272c26913ec5ce3","type":"inject","z":"68da015e57374ead","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":200,"y":340,"wires":[["57bf743e6aa38343"]]},{"id":"9e5ee9ee49efea8b","type":"debug","z":"68da015e57374ead","name":"debug 4","active":true,"tosidebar":true,"console":true,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":530,"y":340,"wires":[]},{"id":"0a4285d0e4d5c927","type":"venv","z":"68da015e57374ead","venvconfig":"2b21ae15341abd9a","name":"","code":"print('hello')\nprint('こんにちは')","continuous":false,"x":370,"y":100,"wires":[["30a4929b48ae0e17"]]},{"id":"4086a3791f42f570","type":"inject","z":"68da015e57374ead","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":200,"y":100,"wires":[["0a4285d0e4d5c927"]]},{"id":"30a4929b48ae0e17","type":"debug","z":"68da015e57374ead","name":"debug 5","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":520,"y":100,"wires":[]},{"id":"2b21ae15341abd9a","type":"venv-config","venvname":"pyenv","version":"default"}]
```