### PR TITLE
Add message to stop processing of venv exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The number of running nodes is displayed in the status.
 
 ![running-status.png](./img/running-status.png)
 
+The venv node stops execution when `msg.kill` or `msg.terminate` is set to `true`, aligning its behavior with Node-RED's `exec` node.
+
 ### pip node
 
 pip(.exe) is in the ./pyenv/Scripts/pip.exe or Python virtual environment you have added.
@@ -67,6 +69,8 @@ Then you can execute it with arguments in Execute mode.
 
 ![venv-exec-list.jpg](./img/venv-exec-list.jpg)
 ![venv-exec-execute.jpg](./img/venv-exec-execute.jpg)
+
+The venv-exec node stops execution when either `msg.kill` or `msg.terminate` is set to `true`, aligning its behavior with Node-RED's `exec` node.
 
 ### venv-config (config node)
 

--- a/node/locales/en-US/venv-exec.json
+++ b/node/locales/en-US/venv-exec.json
@@ -6,6 +6,8 @@
     "executable": "Executable",
     "argument": "Argument",
     "standby": "Standby",
+    "running-continuous": "Running Continuous",
+    "terminate-continuous": "Terminated",
     "executing": "Executing",
     "error": "Error",
     "notFound": "File not found"

--- a/node/locales/ja/venv-exec.json
+++ b/node/locales/ja/venv-exec.json
@@ -6,6 +6,8 @@
     "executable": "実行ファイル",
     "argument": "引数",
     "standby": "待機",
+    "running-continuous": "連続実行中",
+    "terminate-continuous": "連続実行終了",
     "executing": "実行中",
     "error": "エラー",
     "notFound": "ファイルが見つかりません"

--- a/node/venv-exec.js
+++ b/node/venv-exec.js
@@ -27,6 +27,11 @@ module.exports = function (RED) {
     node.status({ fill: 'green', shape: 'dot', text: 'venv-exec.standby' })
 
     node.on('input', function (msg, send, done) {
+      if (msg.terminate === true || msg.kill === true) {
+        pythonProcess?.kill()
+        return
+      }
+
       if (config.mode === 'list') {
         fs.readdir(venvExec, (err, files) => {
           if (err) {

--- a/node/venv-exec.js
+++ b/node/venv-exec.js
@@ -27,8 +27,6 @@ module.exports = function (RED) {
     let pythonProcess = null // Track the Python process
     node.status({ fill: 'green', shape: 'dot', text: 'venv-exec.standby' })
 
-    const runningText = 'venv-exec.running: '
-
     node.on('input', function (msg, send, done) {
       let terminated = false
       if (msg.terminate === true || msg.kill === true) {
@@ -138,20 +136,6 @@ module.exports = function (RED) {
             done()
           })
         })
-      } else if (!continuous) {
-        runningScripts++
-        node.status({
-          fill: 'blue',
-          shape: 'dot',
-          text: runningText + runningScripts,
-        })
-      } else if (pythonProcess.killed) {
-        node.status({
-          fill: 'yellow',
-          shape: 'dot',
-          text: 'venv-exec.terminate-continuous'
-        })
-        node.standby = true
       }
     })
   }

--- a/node/venv.js
+++ b/node/venv.js
@@ -59,11 +59,9 @@ module.exports = function (RED) {
 
       // Checks if the continuous flag is set and if so then kill the process and set it to undefined.
       // If terminate is set to true return without starting a new continuous process.
-      if (continuous) {
-        pythonProcess?.kill()
-        if (msg.terminate === true) {
-          return
-        }
+      if (continuous && (msg.terminate === true || msg.kill === true)) {
+        pythonProcess?.kill();
+        return;
       }
 
       let code = ''


### PR DESCRIPTION
The execution of a venv-exec node can now be terminated in progress, as well as the venv node's Continuous mode.
When msg.terminate or msg.kill has a true value, the node process is terminated.